### PR TITLE
Include errors in finger results

### DIFF
--- a/wpoke/exceptions.py
+++ b/wpoke/exceptions.py
@@ -1,5 +1,13 @@
-class TargetException(Exception):
+class WpokeException(BaseException):
+    message = ""
+
+
+class TargetException(WpokeException):
     pass
+
+
+class TargetConnectionError(TargetException):
+    message = "Target is down or does no exist"
 
 
 class TargetNotFound(TargetException):
@@ -22,7 +30,7 @@ class MalformedBodyException(TargetException):
     pass
 
 
-class ValidationError(Exception):
+class ValidationError(WpokeException):
     def __init__(self, message, code=None):
         super().__init__(message)
 
@@ -30,7 +38,7 @@ class ValidationError(Exception):
         self.code = code
 
 
-class DuplicatedFingerException(Exception):
+class DuplicatedFingerException(WpokeException):
     pass
 
 
@@ -38,11 +46,11 @@ class DataStoreAttributeNotFound(AttributeError):
     pass
 
 
-class ThemePathMissingException(Exception):
+class ThemePathMissingException(WpokeException):
     pass
 
 
-class BundledThemeException(Exception):
+class BundledThemeException(WpokeException):
     message = (
         "The target might be using a package manager to bundle its "
         "assets, like webpack, parcel or browserify"

--- a/wpoke/fingers/theme/crawler.py
+++ b/wpoke/fingers/theme/crawler.py
@@ -193,7 +193,6 @@ class WPThemeMetadataCrawler:
 
     async def get_theme(self, url: str) -> List[WPThemeMetadata]:
         try:
-
             html_content = await self.fetch_html_body(url)
 
             if not html_content:
@@ -227,8 +226,8 @@ class WPThemeMetadataCrawler:
             return theme_models
         except aiohttp.client.TooManyRedirects:
             raise general_exceptions.NastyTargetException
-        except aiohttp.client.ClientConnectionError:
-            raise general_exceptions.TargetInternalServerError
+        except aiohttp.client.ClientConnectionError as e:
+            raise general_exceptions.TargetConnectionError() from e
         except aiohttp.ServerTimeoutError:
             raise general_exceptions.TargetTimeout
         except aiohttp.client.ClientError:

--- a/wpoke/hand.py
+++ b/wpoke/hand.py
@@ -1,14 +1,11 @@
-import logging
 from datetime import datetime
 from typing import Any, AnyStr, Dict, Optional, List, Type
 
 from aiohttp import ClientSession
 
-from .exceptions import DuplicatedFingerException
+from .exceptions import DuplicatedFingerException, WpokeException
 from .finger import BaseFinger
 from .models import HandResult, FingerResult
-
-logger = logging.getLogger(__name__)
 
 
 def _now():
@@ -72,9 +69,10 @@ class Hand:
             result.started_at = _now()
             try:
                 result.data = await finger.run(target_url)
-            except Exception as e:
-                logger.error(str(e))
+            except WpokeException as e:
+                result.data = None
                 result.status = 1
+                result.errors.append(e.message)
             else:
                 result.status = 0
             result.finished_at = _now()

--- a/wpoke/models/__init__.py
+++ b/wpoke/models/__init__.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import AnyStr, Dict, List
+from typing import AnyStr, Dict, List, Optional
 
 import serpy
 
@@ -31,6 +31,7 @@ class FingerResult(TimeitResultMixin):
     status: int
     finger_origin: AnyStr
     data: Dict
+    errors: Optional[List[AnyStr]] = []
 
 
 class FingerResultSerializer(serpy.Serializer, TimeitResultSerializerMixin):
@@ -38,6 +39,7 @@ class FingerResultSerializer(serpy.Serializer, TimeitResultSerializerMixin):
     finger_origin = serpy.StrField(required=True)
     runtime = serpy.FloatField(required=True)
     data = serpy.Field(required=True)
+    errors = serpy.Field(required=False)
 
 
 class HandResult(TimeitResultMixin):


### PR DESCRIPTION
In order to better catch errors during the scraping stage, exception
handling has been improved to the point of self-implementing a base
exception for all the project: WpokeException. This type inherits from
'BaseException', the recommended type to be overriden should error handling
behaviour to be customized.

This commit also adds an 'errors' field to FingerResult type to store which
errors have been yielded for every finger.

Closes https://github.com/sonirico/wpoke/issues/7