### PR TITLE
Disable strict checks over SSL connections (ref #8)

### DIFF
--- a/wpoke/conf.py
+++ b/wpoke/conf.py
@@ -20,7 +20,7 @@ USER_AGENT = (
 )
 
 INSTALLED_FINGERS = ("theme",)
-
+SSL_ENABLED = bool(os.getenv("SSL_ENABLED", False))
 MAX_REDIRECTS = int(os.getenv("MAX_REDIRECTS", 3))
 
 
@@ -73,6 +73,9 @@ class InvalidCliConfigurationException(Exception):
 
 
 class Settings:
+    ssl_enabled: SettingAttr = SettingAttr(
+        "ssl_enabled", ctxv.ContextVar("ssl_enabled", default=SSL_ENABLED)
+    )
     user_agent: SettingAttr = SettingAttr(
         "user_agent", ctxv.ContextVar("user_agent", default=USER_AGENT)
     )

--- a/wpoke/fingers/theme/crawler.py
+++ b/wpoke/fingers/theme/crawler.py
@@ -130,6 +130,7 @@ class WPThemeMetadataConfiguration:
     timeout: int = settings.timeout
     user_agent: str = settings.user_agent
     max_redirects: int = settings.max_redirects
+    ssl_enabled: bool = settings.ssl_enabled
 
 
 class WPThemeMetadataCrawler:
@@ -145,6 +146,7 @@ class WPThemeMetadataCrawler:
     @property
     def request_options(self):
         return dict(
+            ssl=self.http_config.ssl_enabled,
             timeout=self.http_config.timeout,
             max_redirects=self.http_config.max_redirects,
             headers={"User-Agent": self.http_config.user_agent},


### PR DESCRIPTION
This commit adds a configuration flag to disable SSL
checks performed by aiohttp. Over a scan, MITM attacks
are not that important, so it has been kept disabled
by default.