### PR TITLE
feat: make wpoke event loop policy agnostic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ python:
   - "3.8"
   - "nightly"
 
+before_install:
+  - sudo apt-get install -qq libxml2-dev libxmlsec1-dev libxslt-dev
+  - sudo apt-get install -qq python-dev python-lxml python-libxml2
+  - sudo apt-get install -qq python-libxslt1 libxml2
+  - sudo apt-get install -qq build-essential
+
 install:
   - pip install -U pip
   - pip install tox-travis

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,10 @@
-import asyncio
 import os
 
 import pytest
-import uvloop
 
-asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+from wpoke import set_event_loop_policy
+
+set_event_loop_policy()
 
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
 TESTS_ROOT = os.path.join(PROJECT_ROOT, 'tests')

--- a/requirements.lock
+++ b/requirements.lock
@@ -17,5 +17,4 @@ python-dotenv==0.10.3
 serpy==0.3.1
 six==1.12.0
 toml==0.10.0
-uvloop==0.13.0
 yarl==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 serpy
 lxml
 ipaddress
-uvloop
 aiohttp
 dynaconf
 aiodns

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,12 @@
 [tox]
 skipsdist = true
 isolated_build = true
-envlist = py37, flake8, black
+envlist = py{37,38}, flake8, black
 
 [testenv]
 deps =
     -rrequirements.lock
     -rrequirements-dev.txt
-
-[testenv:py37]
-skip_install = true
 commands =
     pytest -rf --disable-warnings tests/ {posargs}
 

--- a/wpoke-cli.py
+++ b/wpoke-cli.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import sys
 
-import uvloop
+import wpoke
 from aiohttp import ClientSession
 
 from wpoke.conf import InvalidCliConfigurationException, settings
@@ -104,7 +104,7 @@ async def main():
 
 if __name__ == '__main__':
     try:
-        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        wpoke.set_event_loop_policy()
         loop = asyncio.get_event_loop()
         loop.run_until_complete(main())
     except KeyboardInterrupt:

--- a/wpoke/__init__.py
+++ b/wpoke/__init__.py
@@ -1,0 +1,11 @@
+import asyncio
+
+
+def set_event_loop_policy():
+    try:
+        import uvloop
+
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    except ImportError:
+        # Falling back to default event loop policy
+        pass

--- a/wpoke/fingers/theme/crawler.py
+++ b/wpoke/fingers/theme/crawler.py
@@ -2,6 +2,7 @@ import asyncio
 import itertools
 import re
 from dataclasses import dataclass
+from io import StringIO
 from typing import List, Optional, Set, Iterator, Union
 
 import aiohttp
@@ -82,7 +83,12 @@ def extract_theme_path_candidates(url: str, html: str) -> Optional[List[str]]:
             by the theme creator intentionally.
     """
 
-    tree = etree.HTML(html)
+    html = html.strip()
+    if not html:
+        return None
+
+    parser = etree.HTMLParser()
+    tree = etree.parse(StringIO(html), parser)
 
     if tree is None:
         return None


### PR DESCRIPTION
In order to gain python3.8 compatibility, uvloop will be only
used only if installed, but will NOT be carried as a transient
dependency.