### PR TITLE
fix: segregated version information

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [master]
+
+- Added build and install test stages for tox
+- Fixed segregated version number, split in several files
+
 ## [0.1.2 - 2019-10-19]
 
 - Fixed entrypoint script not being included within PYTHONPATH

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ from collections import OrderedDict
 
 from setuptools import find_packages, setup
 
+from wpoke.version import VERSION
+
 with io.open('README.rst', 'rt', encoding='utf8') as f:
     readme = f.read()
 
@@ -11,7 +13,7 @@ with io.open('requirements.txt', 'rt', encoding='utf8') as f:
 
 setup(
     name='wpoke',
-    version='0.1.3',
+    version=VERSION,
     url='https://pypi.org/project/wpoke/',
     project_urls=OrderedDict((
         ('Code', 'https://github.com/sonirico/wpoke/'),

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = true
 isolated_build = true
-envlist = py{37,38}, flake8, black
+envlist = py{37,38}, flake8, black, build, install
 
 [testenv]
 deps =
@@ -22,3 +22,9 @@ deps =
     black
 commands =
     black --check --verbose wpoke
+
+[testenv:build]
+commands = python setup.py sdist bdist_wheel
+
+[testenv:install]
+commands = python setup.py install

--- a/wpoke/bin/wpoke-cli
+++ b/wpoke/bin/wpoke-cli
@@ -20,30 +20,49 @@ def extract_cli_options(hand: Hand):
     Based on the cli options configured in every registry, load the
     pertinent settings from them
     """
-    parser = argparse.ArgumentParser(
-        description='WordPress information gathering tool')
-    parser.add_argument('url', help='Target WordPress site. Can be any URL')
-    parser.add_argument('-u', '--user-agent', type=str, dest='useragent',
-                        help='User agent to use',
-                        required=False)
-    parser.add_argument('-tt', '--timeout', type=str, dest='timeout',
-                        help='Global default timeout for all requests',
-                        required=False)
-    parser.add_argument('-r', '--max-redirects', type=str, dest='max_redirects',
-                        help='Global default max redirects for each HTTP call',
-                        required=False)
-    parser.add_argument('-f', '--format', type=str, dest='render_format',
-                        help='Output format. {json|cli}',
-                        required=False)
+    parser = argparse.ArgumentParser(description="WordPress information gathering tool")
+    parser.add_argument("url", help="Target WordPress site. Can be any URL")
+    parser.add_argument(
+        "-u",
+        "--user-agent",
+        type=str,
+        dest="useragent",
+        help="User agent to use",
+        required=False,
+    )
+    parser.add_argument(
+        "-tt",
+        "--timeout",
+        type=str,
+        dest="timeout",
+        help="Global default timeout for all requests",
+        required=False,
+    )
+    parser.add_argument(
+        "-r",
+        "--max-redirects",
+        type=str,
+        dest="max_redirects",
+        help="Global default max redirects for each HTTP call",
+        required=False,
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        dest="render_format",
+        help="Output format. {json|cli}",
+        required=False,
+    )
 
     for lookup_key, finger in hand.registered_fingers:
-        short_arg_name = getattr(finger.Cli, 'short_flag', None)
-        long_arg_name = getattr(finger.Cli, 'long_flag', None)
-        help_text = getattr(finger.Cli, 'help_text', None)
-        required = getattr(finger.Cli, 'required', False)
+        short_arg_name = getattr(finger.Cli, "short_flag", None)
+        long_arg_name = getattr(finger.Cli, "long_flag", None)
+        help_text = getattr(finger.Cli, "help_text", None)
+        required = getattr(finger.Cli, "required", False)
 
         pargs = []
-        pkwargs = {'dest': lookup_key, 'action': 'store_true'}
+        pkwargs = {"dest": lookup_key, "action": "store_true"}
 
         if short_arg_name:
             pargs.append(short_arg_name)
@@ -51,9 +70,9 @@ def extract_cli_options(hand: Hand):
             pargs.append(long_arg_name)
 
         if help_text:
-            pkwargs['help'] = help_text
+            pkwargs["help"] = help_text
         if required is not None:
-            pkwargs['required'] = required
+            pkwargs["required"] = required
 
         parser.add_argument(*pargs, **pkwargs)
 
@@ -76,7 +95,7 @@ def load_settings(cli_options):
     # Output format
     if cli_options.render_format:
         if cli_options.render_format not in settings.ALLOWED_FORMATS:
-            message = f'unknown format: {cli_options.render_format}'
+            message = f"unknown format: {cli_options.render_format}"
             raise InvalidCliConfigurationException(message)
         settings.output_format = cli_options.render_format
 
@@ -102,7 +121,7 @@ async def main():
         print(json.dumps(hand_serializer.data, indent=2))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         wpoke.set_event_loop_policy()
         loop = asyncio.get_event_loop()

--- a/wpoke/bin/wpoke-cli.py
+++ b/wpoke/bin/wpoke-cli.py
@@ -20,30 +20,49 @@ def extract_cli_options(hand: Hand):
     Based on the cli options configured in every registry, load the
     pertinent settings from them
     """
-    parser = argparse.ArgumentParser(
-        description='WordPress information gathering tool')
-    parser.add_argument('url', help='Target WordPress site. Can be any URL')
-    parser.add_argument('-u', '--user-agent', type=str, dest='useragent',
-                        help='User agent to use',
-                        required=False)
-    parser.add_argument('-tt', '--timeout', type=str, dest='timeout',
-                        help='Global default timeout for all requests',
-                        required=False)
-    parser.add_argument('-r', '--max-redirects', type=str, dest='max_redirects',
-                        help='Global default max redirects for each HTTP call',
-                        required=False)
-    parser.add_argument('-f', '--format', type=str, dest='render_format',
-                        help='Output format. {json|cli}',
-                        required=False)
+    parser = argparse.ArgumentParser(description="WordPress information gathering tool")
+    parser.add_argument("url", help="Target WordPress site. Can be any URL")
+    parser.add_argument(
+        "-u",
+        "--user-agent",
+        type=str,
+        dest="useragent",
+        help="User agent to use",
+        required=False,
+    )
+    parser.add_argument(
+        "-tt",
+        "--timeout",
+        type=str,
+        dest="timeout",
+        help="Global default timeout for all requests",
+        required=False,
+    )
+    parser.add_argument(
+        "-r",
+        "--max-redirects",
+        type=str,
+        dest="max_redirects",
+        help="Global default max redirects for each HTTP call",
+        required=False,
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        dest="render_format",
+        help="Output format. {json|cli}",
+        required=False,
+    )
 
     for lookup_key, finger in hand.registered_fingers:
-        short_arg_name = getattr(finger.Cli, 'short_flag', None)
-        long_arg_name = getattr(finger.Cli, 'long_flag', None)
-        help_text = getattr(finger.Cli, 'help_text', None)
-        required = getattr(finger.Cli, 'required', False)
+        short_arg_name = getattr(finger.Cli, "short_flag", None)
+        long_arg_name = getattr(finger.Cli, "long_flag", None)
+        help_text = getattr(finger.Cli, "help_text", None)
+        required = getattr(finger.Cli, "required", False)
 
         pargs = []
-        pkwargs = {'dest': lookup_key, 'action': 'store_true'}
+        pkwargs = {"dest": lookup_key, "action": "store_true"}
 
         if short_arg_name:
             pargs.append(short_arg_name)
@@ -51,9 +70,9 @@ def extract_cli_options(hand: Hand):
             pargs.append(long_arg_name)
 
         if help_text:
-            pkwargs['help'] = help_text
+            pkwargs["help"] = help_text
         if required is not None:
-            pkwargs['required'] = required
+            pkwargs["required"] = required
 
         parser.add_argument(*pargs, **pkwargs)
 
@@ -76,7 +95,7 @@ def load_settings(cli_options):
     # Output format
     if cli_options.render_format:
         if cli_options.render_format not in settings.ALLOWED_FORMATS:
-            message = f'unknown format: {cli_options.render_format}'
+            message = f"unknown format: {cli_options.render_format}"
             raise InvalidCliConfigurationException(message)
         settings.output_format = cli_options.render_format
 
@@ -102,7 +121,7 @@ async def main():
         print(json.dumps(hand_serializer.data, indent=2))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         wpoke.set_event_loop_policy()
         loop = asyncio.get_event_loop()

--- a/wpoke/version.py
+++ b/wpoke/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.0"
+VERSION = "0.1.3"


### PR DESCRIPTION
This commit centralizes version number on wpoke/version.py file,
intended to be imported within setup.py script mainly.

Additionally, this commits adds to envs to tox test runner manager:

- build: test build can be performed (python setup.py sdist bdist_wheel)
- install: test whether the library actually installs