### PR TITLE
fix: returned uris with no protocol scheme

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [master]
 
+- Fixed internal server error caused when target sites returned
+  links to resources without protocol scheme
 - Added build and install test stages for tox
 - Fixed segregated version number, split in several files
 

--- a/conftest.py
+++ b/conftest.py
@@ -7,11 +7,11 @@ from wpoke import set_event_loop_policy
 set_event_loop_policy()
 
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
-TESTS_ROOT = os.path.join(PROJECT_ROOT, 'tests')
-FIXTURES_ROOT = os.path.join(TESTS_ROOT, 'fixtures')
+TESTS_ROOT = os.path.join(PROJECT_ROOT, "tests")
+FIXTURES_ROOT = os.path.join(TESTS_ROOT, "fixtures")
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 def fixture_file_content(request):
     def inner(cls, file_name):
         with open(os.path.join(FIXTURES_ROOT, file_name)) as fd:
@@ -21,7 +21,7 @@ def fixture_file_content(request):
     request.cls.fixture_content = inner
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def read_fixture():
     def inner(file_name):
         with open(os.path.join(FIXTURES_ROOT, file_name)) as fd:

--- a/setup.py
+++ b/setup.py
@@ -5,42 +5,35 @@ from setuptools import find_packages, setup
 
 from wpoke.version import VERSION
 
-with io.open('README.rst', 'rt', encoding='utf8') as f:
+with io.open("README.rst", "rt", encoding="utf8") as f:
     readme = f.read()
 
-with io.open('requirements.txt', 'rt', encoding='utf8') as f:
+with io.open("requirements.txt", "rt", encoding="utf8") as f:
     install_requires = f.readlines()
 
 setup(
-    name='wpoke',
+    name="wpoke",
     version=VERSION,
-    url='https://pypi.org/project/wpoke/',
-    project_urls=OrderedDict((
-        ('Code', 'https://github.com/sonirico/wpoke/'),
-        ('Issue tracker', 'https://github.com/sonirico/wpoke/issues'),
-    )),
-    license='MIT',
-    author='Marcos Sanchez',
-    author_email='marsanben92@gmail.com',
-    maintainer='Marcos Sanchez',
-    maintainer_email='marsanben92@gmail.com',
-    description='WordPress information gathering tool',
+    url="https://pypi.org/project/wpoke/",
+    project_urls=OrderedDict(
+        (
+            ("Code", "https://github.com/sonirico/wpoke/"),
+            ("Issue tracker", "https://github.com/sonirico/wpoke/issues"),
+        )
+    ),
+    license="MIT",
+    author="Marcos Sanchez",
+    author_email="marsanben92@gmail.com",
+    maintainer="Marcos Sanchez",
+    maintainer_email="marsanben92@gmail.com",
+    description="WordPress information gathering tool",
     long_description=readme,
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    platforms='any',
-    python_requires='>=3.7',
+    platforms="any",
+    python_requires=">=3.7",
     install_requires=install_requires,
-    extras_require={
-        'dev': [
-            'pytest',
-            'tox',
-        ],
-        'docs': [
-        ]
-    },
-    scripts=[
-        'wpoke/bin/wpoke-cli'
-    ],
+    extras_require={"dev": ["pytest", "tox"], "docs": []},
+    scripts=["wpoke/bin/wpoke-cli"],
 )

--- a/tests/fixtures/crawlers/theme/html/no_scheme.html
+++ b/tests/fixtures/crawlers/theme/html/no_scheme.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Sample wordpress site</title>
+
+    <!-- consider normal.wp.com is served with HTTPS -->
+    <link href="//normal.wp.com/wp-content/themes/unir.net/style.css" />
+
+</head>
+<body>
+Im just a dummy wordpress site, with nothing at all to show. But hey! I
+have several links to my theme, both as links and scripts. Happy crawling!
+
+<script src="//normal.wp.com/wp-content/hardcodedjs/main.js" >
+    // This script should not be fetched when extracting candidate
+    // theme urls
+</script>
+<script src="//normal.wp.com/wp-content/themes/unir.net/js/main.js" ></script>
+</body>
+</html>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from wpoke.conf import SettingAttr
 
 
 class TestSettings:
-    test_key = SettingAttr('test_key_b', ContextVar('no_test', default=1))
+    test_key = SettingAttr("test_key_b", ContextVar("no_test", default=1))
 
 
 class TestSettingsSetAttribute(unittest.TestCase):

--- a/tests/test_fingers/test_theme/test_crawler.py
+++ b/tests/test_fingers/test_theme/test_crawler.py
@@ -4,9 +4,9 @@ import pytest
 from asynctest import CoroutineMock
 
 import wpoke.exceptions
+from wpoke.client import URL
 from wpoke.fingers.theme.crawler import WPThemeMetadataCrawler
 from wpoke.fingers.theme.crawler import extract_info_from_css
-from wpoke.fingers.theme.crawler import extract_theme_path_candidates
 from wpoke.fingers.theme.crawler import remove_duplicated_theme_urls
 from wpoke.fingers.theme.crawler import truncate_theme_url
 
@@ -17,132 +17,149 @@ async def test_get_screenshot():
     session.request.return_value.__aenter__.return_value.status = 200
     session.request.return_value.__aenter__.return_value.text = CoroutineMock()
     crawler = WPThemeMetadataCrawler(http_session=session)
-    payload = 'http://wpoke.app/wp-content/themes/hola/'
+    payload = "http://wpoke.app/wp-content/themes/hola/"
     actual = await crawler.get_screenshot(payload)
-    expected = f'{payload}screenshot.jpeg'
+    expected = f"{payload}screenshot.jpeg"
     assert actual == expected
 
 
-@pytest.mark.parametrize("actual, expected", [
-    ('http://un-dominio.es/wp-content/themes/twelve/plugins/jquery.min.js',
-     'http://un-dominio.es/wp-content/themes/twelve/'),
-
-    ('http://otro-dominio.es/wp-content/themes/fifteen/',
-     'http://otro-dominio.es/wp-content/themes/fifteen/'),
-
-    ('http://y-otro-dominio.mas/wp-content/themes/fifteen/style.css',
-     'http://y-otro-dominio.mas/wp-content/themes/fifteen/'),
-])
+@pytest.mark.parametrize(
+    "actual, expected",
+    [
+        (
+            "http://un-dominio.es/wp-content/themes/twelve/plugins/jquery.min.js",
+            "http://un-dominio.es/wp-content/themes/twelve/",
+        ),
+        (
+            "http://otro-dominio.es/wp-content/themes/fifteen/",
+            "http://otro-dominio.es/wp-content/themes/fifteen/",
+        ),
+        (
+            "http://y-otro-dominio.mas/wp-content/themes/fifteen/style.css",
+            "http://y-otro-dominio.mas/wp-content/themes/fifteen/",
+        ),
+    ],
+)
 def test_truncate_url(actual, expected):
     assert truncate_theme_url(actual) == expected
 
 
-@pytest.mark.parametrize("urls, expected", [
-    (
+@pytest.mark.parametrize(
+    "urls, expected",
+    [
+        (
             [
-                'http://wpoke.app/wp-content/themes/pepe/jquery.js',
-                'http://wpoke.app/wp-content/themes/paco/jquery.js',
-                'http://wpoke.app/wp-content/themes/paco/plugins/ui/widget.js',
-                'http://wpoke.app/wp-content/themes/pepe/style.css'
+                "http://wpoke.app/wp-content/themes/pepe/jquery.js",
+                "http://wpoke.app/wp-content/themes/paco/jquery.js",
+                "http://wpoke.app/wp-content/themes/paco/plugins/ui/widget.js",
+                "http://wpoke.app/wp-content/themes/pepe/style.css",
             ],
             {
-                'http://wpoke.app/wp-content/themes/pepe/',
-                'http://wpoke.app/wp-content/themes/paco/'
-            }
-    )
-])
+                "http://wpoke.app/wp-content/themes/pepe/",
+                "http://wpoke.app/wp-content/themes/paco/",
+            },
+        )
+    ],
+)
 def test_remove_duplicated_urls(urls, expected):
     actual = remove_duplicated_theme_urls(urls)
     unittest.TestCase().assertSetEqual(actual, expected)
 
 
-@pytest.mark.usefixtures('fixture_file_content', autouse=True)
+@pytest.mark.usefixtures("fixture_file_content", autouse=True)
 class TestThemeCrawlerExtractInfoFromCSS(unittest.TestCase):
     def test_extract_css_info_normal(self):
-        mocked_css = self.fixture_content('crawlers/theme/css/normal.css')
+        mocked_css = self.fixture_content("crawlers/theme/css/normal.css")
 
         wp_metadata = extract_info_from_css(mocked_css)
 
-        assert 'Baskerville' == wp_metadata.theme_name
-        assert 'baskerville' == wp_metadata.text_domain
-        assert '1.19' == wp_metadata.version
-        assert 'A beautiful, responsive ...' == wp_metadata.description
+        assert "Baskerville" == wp_metadata.theme_name
+        assert "baskerville" == wp_metadata.text_domain
+        assert "1.19" == wp_metadata.version
+        assert "A beautiful, responsive ..." == wp_metadata.description
 
     def test_extract_css_info_empty(self):
-        mocked_css = self.fixture_content('crawlers/theme/css/empty.css')
+        mocked_css = self.fixture_content("crawlers/theme/css/empty.css")
 
         with self.assertRaises(wpoke.exceptions.BundledThemeException):
             extract_info_from_css(mocked_css)
 
     def test_extract_css_info_duplicated_fetchs_first_match(self):
-        mocked_css = self.fixture_content('crawlers/theme/css/duplicated.css')
+        mocked_css = self.fixture_content("crawlers/theme/css/duplicated.css")
 
         wp_metadata = extract_info_from_css(mocked_css)
 
-        assert 'Baskerville' == wp_metadata.theme_name
-        assert 'baskerville' == wp_metadata.text_domain
+        assert "Baskerville" == wp_metadata.theme_name
+        assert "baskerville" == wp_metadata.text_domain
 
     def test_empty_value_does_not_fallback_to_next(self):
-        mocked_css = self.fixture_content(
-            'crawlers/theme/css/empty_next_fallback.css')
+        mocked_css = self.fixture_content("crawlers/theme/css/empty_next_fallback.css")
 
         wp_metadata = extract_info_from_css(mocked_css)
 
-        assert 'Divi' == wp_metadata.theme_name
-        assert wp_metadata.author is ''
-        assert wp_metadata.author_uri == 'divi.com'
+        assert "Divi" == wp_metadata.theme_name
+        assert wp_metadata.author is ""
+        assert wp_metadata.author_uri == "divi.com"
 
 
-@pytest.mark.usefixtures('fixture_file_content', autouse=True)
+@pytest.mark.usefixtures("fixture_file_content", autouse=True)
 class TestThemeCrawlerExtractCandidateURLs(object):
     def test_extract_candidate_theme_urls_ok(self):
-        mocked_html = self.fixture_content('crawlers/theme/html/normal.html')
-        target_url = 'https://normal.wp.com/'
-        actual = extract_theme_path_candidates(target_url, mocked_html)
-        expected = [
-            "https://normal.wp.com/wp-content/themes/baskerville/",
-        ]
+        mocked_html = self.fixture_content("crawlers/theme/html/normal.html")
+        target_url = "https://normal.wp.com/"
+        crawler = WPThemeMetadataCrawler(
+            http_session=None, canonical_url=URL(target_url)
+        )
+        actual = crawler.extract_theme_path_candidates(mocked_html)
+        expected = ["https://normal.wp.com/wp-content/themes/baskerville/"]
 
         for expected_url in expected:
             assert expected_url in actual
 
     def test_extract_candidate_urls_have_not_duplicates(self):
-        mocked_html = self.fixture_content(
-            'crawlers/theme/html/duplicates.html')
-        target_url = 'https://duplicates.wp.com/'
+        mocked_html = self.fixture_content("crawlers/theme/html/duplicates.html")
+        target_url = "https://duplicates.wp.com/"
+        crawler = WPThemeMetadataCrawler(
+            http_session=None, canonical_url=URL(target_url)
+        )
+        actual = crawler.extract_theme_path_candidates(mocked_html)
 
-        actual = extract_theme_path_candidates(target_url, mocked_html)
-        expected = [
-            "https://duplicates.wp.com/wp-content/themes/baskerville/",
-        ]
+        expected = ["https://duplicates.wp.com/wp-content/themes/baskerville/"]
 
         for expected_url in expected:
             assert expected_url in actual
 
     def test_extract_candidate_urls_from_empty_response(self):
-        mocked_html = self.fixture_content('crawlers/theme/html/empty.html')
-        target_url = 'http://vacuum.io/'
+        mocked_html = self.fixture_content("crawlers/theme/html/empty.html")
+        target_url = "http://vacuum.io/"
+        crawler = WPThemeMetadataCrawler(
+            http_session=None, canonical_url=URL(target_url)
+        )
+        actual = crawler.extract_theme_path_candidates(mocked_html)
 
-        actual = extract_theme_path_candidates(target_url, mocked_html)
         expected = None
 
         assert expected == actual
 
     def test_extract_candidate_urls_from_malformed_response(self):
-        mocked_html = self.fixture_content('crawlers/theme/html/malformed.html')
-        target_url = 'http://ijustbornlikethis.es'
-
-        actual = extract_theme_path_candidates(target_url, mocked_html)
+        mocked_html = self.fixture_content("crawlers/theme/html/malformed.html")
+        target_url = "http://ijustbornlikethis.es"
+        crawler = WPThemeMetadataCrawler(
+            http_session=None, canonical_url=URL(target_url)
+        )
+        actual = crawler.extract_theme_path_candidates(mocked_html)
         expected = []
 
         assert 0 == len(actual)
         assert expected == actual
 
     def test_extract_candidate_urls_from_non_text_response(self):
-        mocked_html = self.fixture_content('crawlers/theme/html/binary.html')
-        target_url = 'http://aoneorazero.com'
-
-        actual = extract_theme_path_candidates(target_url, mocked_html)
+        mocked_html = self.fixture_content("crawlers/theme/html/binary.html")
+        target_url = "http://aoneorazero.com"
+        crawler = WPThemeMetadataCrawler(
+            http_session=None, canonical_url=URL(target_url)
+        )
+        actual = crawler.extract_theme_path_candidates(mocked_html)
         expected = []
 
         assert 0 == len(actual)
@@ -150,11 +167,14 @@ class TestThemeCrawlerExtractCandidateURLs(object):
 
     def test_extracted_urls_same_domain(self):
         mocked_html = self.fixture_content(
-            'crawlers/theme/html/urls_third_parties.html')
-        target_url = 'https://wp.com/whatever/goes/here/'
-
-        actual = extract_theme_path_candidates(target_url, mocked_html)
-        expected = ['https://wp.com/wp-content/themes/millionparsecs/']
+            "crawlers/theme/html/urls_third_parties.html"
+        )
+        target_url = "https://wp.com/whatever/goes/here/"
+        crawler = WPThemeMetadataCrawler(
+            http_session=None, canonical_url=URL(target_url)
+        )
+        actual = crawler.extract_theme_path_candidates(mocked_html)
+        expected = ["https://wp.com/wp-content/themes/millionparsecs/"]
 
         assert 1 == len(actual)
 
@@ -162,25 +182,41 @@ class TestThemeCrawlerExtractCandidateURLs(object):
             assert expected_token in actual
 
     def test_extract_candidate_urls_child_theme_installed(self):
-        mocked_html = self.fixture_content(
-            'crawlers/theme/html/child_theme.html')
-        target_url = 'https://wp.com'
-        actual = extract_theme_path_candidates(target_url, mocked_html)
+        mocked_html = self.fixture_content("crawlers/theme/html/child_theme.html")
+        target_url = "https://wp.com"
+        crawler = WPThemeMetadataCrawler(
+            http_session=None, canonical_url=URL(target_url)
+        )
+        actual = crawler.extract_theme_path_candidates(mocked_html)
         expected = [
             "https://wp.com/wp-content/themes/baskerville/",
-            "https://wp.com/wp-content/themes/baskerville-child-001/"
+            "https://wp.com/wp-content/themes/baskerville-child-001/",
         ]
 
         for expected_uri in expected:
             assert expected_uri in actual
 
     def test_extract_candidate_urls_from_global_cross_search(self):
-        mocked_html = self.fixture_content(
-            'crawlers/theme/html/sites/sozpic.com.html')
-        target_url = 'https://www.sozpic.com'
-        actual = extract_theme_path_candidates(target_url, mocked_html)
+        mocked_html = self.fixture_content("crawlers/theme/html/sites/sozpic.com.html")
+        target_url = "https://www.sozpic.com"
+        crawler = WPThemeMetadataCrawler(
+            http_session=None, canonical_url=URL(target_url)
+        )
+        actual = crawler.extract_theme_path_candidates(mocked_html)
+        expected = ["https://www.sozpic.com/wp-content/themes/mana/"]
+
+        for expected_uri in expected:
+            assert expected_uri in actual
+
+    def test_returned_uris_with_no_schemes_inherit_canonical(self):
+        mocked_html = self.fixture_content("crawlers/theme/html/no_scheme.html")
+        target_url = "https://www.unir.net"
+        crawler = WPThemeMetadataCrawler(
+            http_session=None, canonical_url=URL(target_url)
+        )
+        actual = crawler.extract_theme_path_candidates(mocked_html)
         expected = [
-            "https://www.sozpic.com/wp-content/themes/mana/"
+            "https://normal.wp.com/wp-content/themes/unir.net/"
         ]
 
         for expected_uri in expected:

--- a/tests/test_fingers/test_theme/test_models.py
+++ b/tests/test_fingers/test_theme/test_models.py
@@ -10,15 +10,14 @@ class TestWPThemeMetadata(unittest.TestCase):
         serializer = WPThemeMetadataSerializer(wp_metadata_model)
         w_serialized = serializer.data
 
-        self.assertIsInstance(w_serialized['tags'], list)
-        self.assertIsNone(w_serialized['theme_name'])
+        self.assertIsInstance(w_serialized["tags"], list)
+        self.assertIsNone(w_serialized["theme_name"])
 
     def test_serialize_tags_field(self):
         wp_metadata_model = WPThemeMetadata()
-        wp_metadata_model.tags = 'hacking, programming  , devops'
+        wp_metadata_model.tags = "hacking, programming  , devops"
 
         serializer = WPThemeMetadataSerializer(wp_metadata_model)
         w_serialized = serializer.data
 
-        self.assertListEqual(w_serialized['tags'], ['hacking', 'programming',
-                                                    'devops'])
+        self.assertListEqual(w_serialized["tags"], ["hacking", "programming", "devops"])

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -18,8 +18,10 @@ class StoreTestCase(TestCase):
             self.fail(f"Expected store to have key '{actual_key}'")
         else:
             if expected_value != actual_value:
-                self.fail(f"Expected store to have value '{expected_value}' "
-                          f"for key '{actual_key}'")
+                self.fail(
+                    f"Expected store to have value '{expected_value}' "
+                    f"for key '{actual_key}'"
+                )
 
     def assert_attribute_equals(self, expected, key_name):
         self.assert_getattr_equals(expected, key_name.upper())
@@ -27,19 +29,19 @@ class StoreTestCase(TestCase):
 
     def test_getattribute(self):
         expected_version = "4.9.10"
-        self.store['WP_VERSION'] = expected_version
-        self.assert_attribute_equals(expected_version, 'WP_VERSION')
+        self.store["WP_VERSION"] = expected_version
+        self.assert_attribute_equals(expected_version, "WP_VERSION")
 
     def test_get_or_set_returns_get(self):
         expected_version = "4.9.10"
-        self.store['WP_VERSION'] = expected_version
-        actual_version = self.store.get_or_set('WP_VERSION', "5.1.0")
+        self.store["WP_VERSION"] = expected_version
+        actual_version = self.store.get_or_set("WP_VERSION", "5.1.0")
         self.assertEqual(expected_version, actual_version)
 
     def test_get_or_raise(self):
-        self.assertRaises(DataStoreAttributeNotFound,
-                          self.store.get_or_raise,
-                          "WP_VERSION")
+        self.assertRaises(
+            DataStoreAttributeNotFound, self.store.get_or_raise, "WP_VERSION"
+        )
 
     def test_get_safe_return_none(self):
         self.assertIsNone(self.store.get_safe("non_existent_key"))
@@ -47,49 +49,46 @@ class StoreTestCase(TestCase):
     def test_get_safe_return_data(self):
         expected_value = "value"
         self.store["non_existent_key"] = expected_value
-        self.assertEqual(expected_value,
-                         self.store.get_safe("non_existent_key"))
+        self.assertEqual(expected_value, self.store.get_safe("non_existent_key"))
 
     def test_get_or_set_returns_set(self):
         expected_version = "4.9.10"
         # self.store['WP_VERSION'] = "whatever"
-        actual_version = self.store.get_or_set('WP_VERSION',
-                                               expected_version)
+        actual_version = self.store.get_or_set("WP_VERSION", expected_version)
         self.assertEqual(expected_version, actual_version)
 
     def test_set_lazy(self):
         expected_version = "4.9.10"
-        self.store['WP_VERSION'] = expected_version
-        self.store.set_lazy('WP_VERSION', "5.1.0")
+        self.store["WP_VERSION"] = expected_version
+        self.store.set_lazy("WP_VERSION", "5.1.0")
         self.assert_attribute_equals(expected_version, "WP_VERSION")
 
     def test_set(self):
         expected_version = "4.9.10"
-        self.store['WP_VERSION'] = "I should be overridden"
-        self.store.set('WP_VERSION', expected_version)
+        self.store["WP_VERSION"] = "I should be overridden"
+        self.store.set("WP_VERSION", expected_version)
         self.assert_attribute_equals(expected_version, "WP_VERSION")
 
     def test_keys(self):
         expected_keys = ["A", "B", "Z"]
-        self.store['Z'] = ""
-        self.store['A'] = ""
-        self.store['B'] = ""
+        self.store["Z"] = ""
+        self.store["A"] = ""
+        self.store["B"] = ""
         self.assertListEqual(expected_keys, self.store.keys())
 
     def test_delete_key_not_exist_should_not_raise_key_error(self):
-        del self.store['WP_VERSION']
+        del self.store["WP_VERSION"]
         self.store.delete("WP_VERSION")
 
     def test_delete_key_does_exist(self):
-        self.store['WP_VERSION'] = "whatever"
+        self.store["WP_VERSION"] = "whatever"
         self.store.delete("WP_VERSION")
-        self.assertRaises(KeyError,
-                          lambda: self.store['WP_VERSION'])
+        self.assertRaises(KeyError, lambda: self.store["WP_VERSION"])
 
     def test_clear(self):
-        self.store['Z'] = ""
-        self.store['A'] = ""
-        self.store['B'] = ""
+        self.store["Z"] = ""
+        self.store["A"] = ""
+        self.store["B"] = ""
         self.assertEqual(3, len(self.store.keys()))
         self.store.clear()
         self.assertEqual(0, len(self.store.keys()))

--- a/tests/test_validators/test_url.py
+++ b/tests/test_validators/test_url.py
@@ -9,39 +9,39 @@ class TestURLValidator(unittest.TestCase):
         validator = URLValidator()
 
         with self.assertRaises(ValidationError):
-            validator('http://localhost/')
+            validator("http://localhost/")
 
     def test_url_cannot_be_loop_back(self):
         validator = URLValidator()
 
         with self.assertRaises(ValidationError):
-            validator('http://127.0.0.1/')
+            validator("http://127.0.0.1/")
 
     def test_http_or_https_allowed(self):
         validator = URLValidator()
 
-        validator('http://test.foo')
-        validator('https://test.foo/')
+        validator("http://test.foo")
+        validator("https://test.foo/")
 
         with self.assertRaises(ValidationError):
-            validator('ftp://test.foo/')
-            validator('ws://test.foo/')
+            validator("ftp://test.foo/")
+            validator("ws://test.foo/")
 
     def test_reserved_ip_ranges_are_not_allowed(self):
         validator = URLValidator()
 
         with self.assertRaises(ValidationError):
-            validator('http://0.0.0.0/foo')
+            validator("http://0.0.0.0/foo")
 
         with self.assertRaises(ValidationError):
-            validator('http://10.255.255.255/foo')
+            validator("http://10.255.255.255/foo")
 
         with self.assertRaises(ValidationError):
-            validator('https://192.168.12.10')
+            validator("https://192.168.12.10")
 
         with self.assertRaises(ValidationError):
-            validator('https://127.0.0.1')
-            validator('https://127.0.1.1')
+            validator("https://127.0.0.1")
+            validator("https://127.0.1.1")
 
         with self.assertRaises(ValidationError):
-            validator('https://172.16.254.233')
+            validator("https://172.16.254.233")

--- a/wpoke/client.py
+++ b/wpoke/client.py
@@ -1,0 +1,22 @@
+from aiohttp.client import URL as aio_url
+
+
+class URL:
+    def __init__(self, url: str):
+        self.url = aio_url(url)
+
+    def __str__(self):
+        return str(self.url)
+
+    def __repr__(self):
+        return repr(self.url)
+
+    @property
+    def scheme(self):
+        return self.url.scheme
+
+    def has_scheme(self):
+        return self.url.scheme in ("http", "https")
+
+    def set_scheme(self, scheme: str):
+        self.url = self.url.with_scheme(scheme)


### PR DESCRIPTION
This commit creates a new type "URL" that checks whether
retrieved urls from scan are valid to be further analyzed. If
not, the scheme from the canonical url (the initial url got after
redirects, if any) will be set.